### PR TITLE
Add CV → skill gap analyzer notebook prototype

### DIFF
--- a/Project-1.ipynb
+++ b/Project-1.ipynb
@@ -1,0 +1,519 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5fce3fd2",
+   "metadata": {},
+   "source": [
+    "# Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3b7177c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: python-docx in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (1.2.0)\n",
+      "Requirement already satisfied: PyPDF2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (3.0.1)\n",
+      "Requirement already satisfied: pandas in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (2.2.3)\n",
+      "Requirement already satisfied: rapidfuzz in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (3.14.0)\n",
+      "Requirement already satisfied: lxml>=3.1.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from python-docx) (6.0.1)\n",
+      "Requirement already satisfied: typing_extensions>=4.9.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from python-docx) (4.12.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (2.9.0.post0)\n",
+      "Requirement already satisfied: numpy>=1.22.4 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (1.26.4)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (2025.1)\n",
+      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (2025.1)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)\n",
+      "Requirement already satisfied: openai in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (1.102.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (0.28.1)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (2.10.6)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (4.12.2)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (4.8.0)\n",
+      "Requirement already satisfied: sniffio in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (1.3.1)\n",
+      "Requirement already satisfied: tqdm>4 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (4.67.1)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (1.9.0)\n",
+      "Requirement already satisfied: jiter<1,>=0.4.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (0.10.0)\n",
+      "Requirement already satisfied: idna>=2.8 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (3.4)\n",
+      "Requirement already satisfied: exceptiongroup>=1.0.2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (1.2.2)\n",
+      "Requirement already satisfied: certifi in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (2024.12.14)\n",
+      "Requirement already satisfied: httpcore==1.* in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.7)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.27.2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (2.27.2)\n",
+      "Requirement already satisfied: colorama in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from tqdm>4->openai) (0.4.6)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install python-docx PyPDF2 pandas rapidfuzz\n",
+    "\n",
+    "# Optional LLMs:\n",
+    "!pip install openai\n",
+    "# !pip install transformers accelerate sentencepiece\n",
+    "# !pip install huggingface_hub\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3e1a2b6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, re, json, textwrap\n",
+    "from collections import defaultdict\n",
+    "import PyPDF2, docx\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Providers\n",
+    "OPENAI_AVAILABLE = False\n",
+    "# HF_TRANSFORMERS_AVAILABLE = False\n",
+    "# HF_HUB_AVAILABLE = False\n",
+    "\n",
+    "try:\n",
+    "    import openai\n",
+    "    OPENAI_AVAILABLE = True\n",
+    "except:\n",
+    "    try:\n",
+    "        from openai import OpenAI\n",
+    "        OPENAI_AVAILABLE = True\n",
+    "    except:\n",
+    "        OPENAI_AVAILABLE = False\n",
+    "\n",
+    "try:\n",
+    "    import transformers\n",
+    "    HF_TRANSFORMERS_AVAILABLE = True\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "try:\n",
+    "    import huggingface_hub\n",
+    "    HF_HUB_AVAILABLE = True\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "def wrap(s, width=100):\n",
+    "    return \"\\n\".join(textwrap.wrap(str(s), width=width))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78dcd6e5",
+   "metadata": {},
+   "source": [
+    "# CV Input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "177de0cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option A \n",
+    "\n",
+    "cv_path = \"C:/Users/Benyamin/OneDrive - University of Portsmouth/Documents/Apply/Job Hunting/2- Full time/3-AI-ML-Engineer/BenyaminEbrahimpour CV_AI-ML_v4_07-13-25.pdf\"\n",
+    "\n",
+    "# Option B\n",
+    "cv_text_manual = \"\"\"\n",
+    "PASTE YOUR CV TEXT HERE IF NEEDED\n",
+    "\"\"\"\n",
+    "# === Paste your target Job Description (JD) text here ===\n",
+    "\n",
+    "jd_text = \"\"\"\n",
+    "YOUR JOB DESCRIPTION\n",
+    "\"\"\"\n",
+    "\n",
+    "# Choose LLM provider: 'openai', 'hf_local', 'hf_inference', '' (auto)\n",
+    "LLM_PROVIDER = ''\n",
+    "OPENAI_MODEL = 'gpt-4o-mini'\n",
+    "# HF_LOCAL_MODEL = 'google/flan-t5-small'\n",
+    "# HF_INFERENCE_MODEL = 'mistralai/Mistral-7B-Instruct-v0.3'\n",
+    "\n",
+    "OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')\n",
+    "# HF_API_TOKEN = os.getenv('HUGGINGFACEHUB_API_TOKEN', '')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b8e898",
+   "metadata": {},
+   "source": [
+    "# Skills Taxonomy & Free Resources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6b47b4cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SKILL_TAXONOMY = {\n",
+    "    \"python\": {\"aliases\": [\"python3\"], \"category\": \"Programming\"},\n",
+    "    \"git\": {\"aliases\": [\"github\", \"version control\"], \"category\": \"MLOps\"},\n",
+    "    \"sql\": {\"aliases\": [\"mysql\", \"postgres\"], \"category\": \"Data\"},\n",
+    "    \"pandas\": {\"aliases\": [\"dataframe\"], \"category\": \"Data\"},\n",
+    "    \"numpy\": {\"aliases\": [\"np\"], \"category\": \"Data\"},\n",
+    "    \"scikit-learn\": {\"aliases\": [\"sklearn\"], \"category\": \"ML\"},\n",
+    "    \"tensorflow\": {\"aliases\": [\"keras\"], \"category\": \"DL\"},\n",
+    "    \"pytorch\": {\"aliases\": [\"torch\"], \"category\": \"DL\"},\n",
+    "    \"nlp\": {\"aliases\": [\"spacy\", \"nltk\"], \"category\": \"ML\"},\n",
+    "    \"time series\": {\"aliases\": [\"forecasting\"], \"category\": \"ML\"},\n",
+    "    \"statistics\": {\"aliases\": [], \"category\": \"Math\"},\n",
+    "    \"docker\": {\"aliases\": [], \"category\": \"MLOps\"},\n",
+    "    \"apis\": {\"aliases\": [\"fastapi\", \"flask\"], \"category\": \"Backend\"},\n",
+    "    \"excel\": {\"aliases\": [], \"category\": \"Data\"},\n",
+    "    \"tableau\": {\"aliases\": [], \"category\": \"Viz\"},\n",
+    "}\n",
+    "\n",
+    "FREE_RESOURCES = {\n",
+    "    \"python\": [(\"CS50 Python\", \"https://cs50.harvard.edu/python/\")],\n",
+    "    \"sql\": [(\"Mode SQL Tutorial\", \"https://mode.com/sql-tutorial/\")],\n",
+    "    \"pandas\": [(\"Kaggle Pandas\", \"https://www.kaggle.com/learn/pandas\")],\n",
+    "    \"numpy\": [(\"NumPy Guide\", \"https://numpy.org/doc/stable/user/index.html\")],\n",
+    "    \"scikit-learn\": [(\"Sklearn Tutorials\", \"https://scikit-learn.org/stable/tutorial/\")],\n",
+    "    \"tensorflow\": [(\"Keras Docs\", \"https://keras.io/\")],\n",
+    "    \"pytorch\": [(\"PyTorch Tutorials\", \"https://pytorch.org/tutorials/\")],\n",
+    "    \"nlp\": [(\"spaCy Course\", \"https://course.spacy.io/\")],\n",
+    "    \"statistics\": [(\"Khan Academy\", \"https://www.khanacademy.org/math/statistics-probability\")],\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f895547f",
+   "metadata": {},
+   "source": [
+    "# CV & JD Parsing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "57293aaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_text_from_pdf(path):\n",
+    "    if PyPDF2 is None: return \"\"\n",
+    "    with open(path, 'rb') as f:\n",
+    "        reader = PyPDF2.PdfReader(f)\n",
+    "        return \"\\n\".join([p.extract_text() or \"\" for p in reader.pages])\n",
+    "\n",
+    "def extract_text_from_docx(path):\n",
+    "    if docx is None: return \"\"\n",
+    "    doc = docx.Document(path)\n",
+    "    return \"\\n\".join([p.text for p in doc.paragraphs])\n",
+    "\n",
+    "def load_cv_text(path, manual):\n",
+    "    if path and os.path.exists(path):\n",
+    "        if path.endswith(\".pdf\"): return extract_text_from_pdf(path)\n",
+    "        if path.endswith(\".docx\"): return extract_text_from_docx(path)\n",
+    "        if path.endswith(\".txt\"): return open(path).read()\n",
+    "    return manual\n",
+    "\n",
+    "cv_text = load_cv_text(cv_path, cv_text_manual)\n",
+    "jd_text_norm = re.sub(r\"\\s+\", \" \", jd_text.lower())\n",
+    "cv_text_norm = re.sub(r\"\\s+\", \" \", cv_text.lower())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1a51f36",
+   "metadata": {},
+   "source": [
+    "# Skill Gap Analysis - Regex Baseline Detector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "09e29115",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def skill_patterns(skill):\n",
+    "    base = [skill.lower()] + SKILL_TAXONOMY[skill][\"aliases\"]\n",
+    "    return [re.compile(rf\"\\b{re.escape(x)}\\b\", re.I) for x in base]\n",
+    "\n",
+    "def detect_skills_regex(text):\n",
+    "    found = {}\n",
+    "    for skill in SKILL_TAXONOMY:\n",
+    "        pats = skill_patterns(skill)\n",
+    "        cnt = sum(len(p.findall(text)) for p in pats)\n",
+    "        if cnt > 0:\n",
+    "            found[skill] = cnt\n",
+    "    return found\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c2b15c1",
+   "metadata": {},
+   "source": [
+    "# LLM Skill Extraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9a2426f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prompt_for_skills(cv, jd):\n",
+    "    taxonomy_list = \"\\n\".join(f\"- {k}\" for k in SKILL_TAXONOMY)\n",
+    "    return f\"\"\"\n",
+    "Extract which skills from this taxonomy appear in the CV and JD.\n",
+    "Return JSON with keys: \"cv_skills\", \"jd_skills\".\n",
+    "\n",
+    "TAXONOMY:\n",
+    "{taxonomy_list}\n",
+    "\n",
+    "CV:\n",
+    "{cv[:3000]}\n",
+    "\n",
+    "JD:\n",
+    "{jd[:3000]}\n",
+    "\"\"\"\n",
+    "\n",
+    "def extract_skills_llm(cv, jd):\n",
+    "    try:\n",
+    "        prompt = prompt_for_skills(cv, jd)\n",
+    "        if OPENAI_AVAILABLE and OPENAI_API_KEY:\n",
+    "            from openai import OpenAI\n",
+    "            client = OpenAI(api_key=OPENAI_API_KEY)\n",
+    "            resp = client.chat.completions.create(\n",
+    "                model=OPENAI_MODEL,\n",
+    "                messages=[{\"role\":\"user\",\"content\": prompt}],\n",
+    "                temperature=0\n",
+    "            )\n",
+    "            data = json.loads(resp.choices[0].message.content)\n",
+    "            return data\n",
+    "    except Exception as e:\n",
+    "        print(\"LLM failed:\", e)\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3ebb0899",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CV skills: ['python', 'git', 'sql', 'pandas', 'numpy', 'pytorch', 'statistics', 'excel', 'tableau']\n",
+      "JD skills: ['python', 'git']\n",
+      "Missing skills: []\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run Detection\n",
+    "llm_result = extract_skills_llm(cv_text_norm, jd_text_norm)\n",
+    "if llm_result:\n",
+    "    cv_skills = {s:1 for s in llm_result[\"cv_skills\"]}\n",
+    "    jd_skills = {s:1 for s in llm_result[\"jd_skills\"]}\n",
+    "else:\n",
+    "    cv_skills = detect_skills_regex(cv_text_norm)\n",
+    "    jd_skills = detect_skills_regex(jd_text_norm)\n",
+    "\n",
+    "missing = [s for s in jd_skills if s not in cv_skills]\n",
+    "print(\"CV skills:\", list(cv_skills))\n",
+    "print(\"JD skills:\", list(jd_skills))\n",
+    "print(\"Missing skills:\", missing)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a1d25f1",
+   "metadata": {},
+   "source": [
+    "# Personalized Learning Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f8384dba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ORDER = [\"python\",\"git\",\"sql\",\"pandas\",\"numpy\",\"scikit-learn\",\"nlp\",\"tensorflow\",\"pytorch\"]\n",
+    "\n",
+    "def build_path(missing):\n",
+    "    ordered = sorted(missing, key=lambda s: ORDER.index(s) if s in ORDER else 999)\n",
+    "    plan = []\n",
+    "    for s in ordered:\n",
+    "        cat = SKILL_TAXONOMY[s][\"category\"]\n",
+    "        res = FREE_RESOURCES.get(s, [])\n",
+    "        plan.append({\n",
+    "            \"Skill\": s,\n",
+    "            \"Category\": cat,\n",
+    "            \"Weeks\": 1 if s in [\"git\",\"excel\"] else 2,\n",
+    "            \"Resources\": res\n",
+    "        })\n",
+    "    return plan\n",
+    "\n",
+    "learning_plan = build_path(missing)\n",
+    "pd.DataFrame(learning_plan)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06041726",
+   "metadata": {},
+   "source": [
+    "# Project Ideas (Portfolio Builders)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1e79251b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Suggested role: data analyst\n",
+      "- KPI dashboard\n",
+      "- Cohort analysis\n",
+      "- Sales forecasting\n"
+     ]
+    }
+   ],
+   "source": [
+    "ROLE_IDEAS = {\n",
+    "    \"data scientist\": [\"End-to-end ML project\", \"NLP classifier\", \"Time series forecasting\"],\n",
+    "    \"data analyst\": [\"KPI dashboard\", \"Cohort analysis\", \"Sales forecasting\"]\n",
+    "}\n",
+    "\n",
+    "role = \"data scientist\" if \"scientist\" in jd_text_norm else \"data analyst\"\n",
+    "print(\"Suggested role:\", role)\n",
+    "for idea in ROLE_IDEAS[role]:\n",
+    "    print(\"-\", idea)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "521a790f",
+   "metadata": {},
+   "source": [
+    "# Export Report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fa2fb5ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Report saved to skillbridge_report.md\n"
+     ]
+    }
+   ],
+   "source": [
+    "report = []\n",
+    "report.append(\"# SkillBridge Plan\\n\")\n",
+    "report.append(\"## Skills\\n\")\n",
+    "report.append(f\"CV skills: {list(cv_skills)}\\n\")\n",
+    "report.append(f\"JD skills: {list(jd_skills)}\\n\")\n",
+    "report.append(f\"Missing: {missing}\\n\")\n",
+    "\n",
+    "report.append(\"\\n## Learning Path\\n\")\n",
+    "for row in learning_plan:\n",
+    "    report.append(f\"- {row['Skill']} ({row['Category']}), {row['Weeks']} weeks\")\n",
+    "\n",
+    "out_path = \"skillbridge_report.md\"\n",
+    "with open(out_path,\"w\") as f:\n",
+    "    f.write(\"\\n\".join(report))\n",
+    "\n",
+    "print(\"Report saved to\", out_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c7e516e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/backend/Project-1.ipynb
+++ b/backend/Project-1.ipynb
@@ -1,0 +1,519 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5fce3fd2",
+   "metadata": {},
+   "source": [
+    "# Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3b7177c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: python-docx in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (1.2.0)\n",
+      "Requirement already satisfied: PyPDF2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (3.0.1)\n",
+      "Requirement already satisfied: pandas in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (2.2.3)\n",
+      "Requirement already satisfied: rapidfuzz in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (3.14.0)\n",
+      "Requirement already satisfied: lxml>=3.1.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from python-docx) (6.0.1)\n",
+      "Requirement already satisfied: typing_extensions>=4.9.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from python-docx) (4.12.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (2.9.0.post0)\n",
+      "Requirement already satisfied: numpy>=1.22.4 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (1.26.4)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (2025.1)\n",
+      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pandas) (2025.1)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)\n",
+      "Requirement already satisfied: openai in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (1.102.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (0.28.1)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (2.10.6)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (4.12.2)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (4.8.0)\n",
+      "Requirement already satisfied: sniffio in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (1.3.1)\n",
+      "Requirement already satisfied: tqdm>4 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (4.67.1)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (1.9.0)\n",
+      "Requirement already satisfied: jiter<1,>=0.4.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from openai) (0.10.0)\n",
+      "Requirement already satisfied: idna>=2.8 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (3.4)\n",
+      "Requirement already satisfied: exceptiongroup>=1.0.2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (1.2.2)\n",
+      "Requirement already satisfied: certifi in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (2024.12.14)\n",
+      "Requirement already satisfied: httpcore==1.* in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.7)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.27.2 in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (2.27.2)\n",
+      "Requirement already satisfied: colorama in c:\\users\\benyamin\\miniconda3\\lib\\site-packages (from tqdm>4->openai) (0.4.6)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install python-docx PyPDF2 pandas rapidfuzz\n",
+    "\n",
+    "# Optional LLMs:\n",
+    "!pip install openai\n",
+    "# !pip install transformers accelerate sentencepiece\n",
+    "# !pip install huggingface_hub\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3e1a2b6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, re, json, textwrap\n",
+    "from collections import defaultdict\n",
+    "import PyPDF2, docx\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Providers\n",
+    "OPENAI_AVAILABLE = False\n",
+    "# HF_TRANSFORMERS_AVAILABLE = False\n",
+    "# HF_HUB_AVAILABLE = False\n",
+    "\n",
+    "try:\n",
+    "    import openai\n",
+    "    OPENAI_AVAILABLE = True\n",
+    "except:\n",
+    "    try:\n",
+    "        from openai import OpenAI\n",
+    "        OPENAI_AVAILABLE = True\n",
+    "    except:\n",
+    "        OPENAI_AVAILABLE = False\n",
+    "\n",
+    "try:\n",
+    "    import transformers\n",
+    "    HF_TRANSFORMERS_AVAILABLE = True\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "try:\n",
+    "    import huggingface_hub\n",
+    "    HF_HUB_AVAILABLE = True\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "def wrap(s, width=100):\n",
+    "    return \"\\n\".join(textwrap.wrap(str(s), width=width))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78dcd6e5",
+   "metadata": {},
+   "source": [
+    "# CV Input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "177de0cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option A \n",
+    "\n",
+    "cv_path = \"C:/Users/Benyamin/OneDrive - University of Portsmouth/Documents/Apply/Job Hunting/2- Full time/3-AI-ML-Engineer/BenyaminEbrahimpour CV_AI-ML_v4_07-13-25.pdf\"\n",
+    "\n",
+    "# Option B\n",
+    "cv_text_manual = \"\"\"\n",
+    "PASTE YOUR CV TEXT HERE IF NEEDED\n",
+    "\"\"\"\n",
+    "# === Paste your target Job Description (JD) text here ===\n",
+    "\n",
+    "jd_text = \"\"\"\n",
+    "YOUR JOB DESCRIPTION\n",
+    "\"\"\"\n",
+    "\n",
+    "# Choose LLM provider: 'openai', 'hf_local', 'hf_inference', '' (auto)\n",
+    "LLM_PROVIDER = ''\n",
+    "OPENAI_MODEL = 'gpt-4o-mini'\n",
+    "# HF_LOCAL_MODEL = 'google/flan-t5-small'\n",
+    "# HF_INFERENCE_MODEL = 'mistralai/Mistral-7B-Instruct-v0.3'\n",
+    "\n",
+    "OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')\n",
+    "# HF_API_TOKEN = os.getenv('HUGGINGFACEHUB_API_TOKEN', '')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b8e898",
+   "metadata": {},
+   "source": [
+    "# Skills Taxonomy & Free Resources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6b47b4cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SKILL_TAXONOMY = {\n",
+    "    \"python\": {\"aliases\": [\"python3\"], \"category\": \"Programming\"},\n",
+    "    \"git\": {\"aliases\": [\"github\", \"version control\"], \"category\": \"MLOps\"},\n",
+    "    \"sql\": {\"aliases\": [\"mysql\", \"postgres\"], \"category\": \"Data\"},\n",
+    "    \"pandas\": {\"aliases\": [\"dataframe\"], \"category\": \"Data\"},\n",
+    "    \"numpy\": {\"aliases\": [\"np\"], \"category\": \"Data\"},\n",
+    "    \"scikit-learn\": {\"aliases\": [\"sklearn\"], \"category\": \"ML\"},\n",
+    "    \"tensorflow\": {\"aliases\": [\"keras\"], \"category\": \"DL\"},\n",
+    "    \"pytorch\": {\"aliases\": [\"torch\"], \"category\": \"DL\"},\n",
+    "    \"nlp\": {\"aliases\": [\"spacy\", \"nltk\"], \"category\": \"ML\"},\n",
+    "    \"time series\": {\"aliases\": [\"forecasting\"], \"category\": \"ML\"},\n",
+    "    \"statistics\": {\"aliases\": [], \"category\": \"Math\"},\n",
+    "    \"docker\": {\"aliases\": [], \"category\": \"MLOps\"},\n",
+    "    \"apis\": {\"aliases\": [\"fastapi\", \"flask\"], \"category\": \"Backend\"},\n",
+    "    \"excel\": {\"aliases\": [], \"category\": \"Data\"},\n",
+    "    \"tableau\": {\"aliases\": [], \"category\": \"Viz\"},\n",
+    "}\n",
+    "\n",
+    "FREE_RESOURCES = {\n",
+    "    \"python\": [(\"CS50 Python\", \"https://cs50.harvard.edu/python/\")],\n",
+    "    \"sql\": [(\"Mode SQL Tutorial\", \"https://mode.com/sql-tutorial/\")],\n",
+    "    \"pandas\": [(\"Kaggle Pandas\", \"https://www.kaggle.com/learn/pandas\")],\n",
+    "    \"numpy\": [(\"NumPy Guide\", \"https://numpy.org/doc/stable/user/index.html\")],\n",
+    "    \"scikit-learn\": [(\"Sklearn Tutorials\", \"https://scikit-learn.org/stable/tutorial/\")],\n",
+    "    \"tensorflow\": [(\"Keras Docs\", \"https://keras.io/\")],\n",
+    "    \"pytorch\": [(\"PyTorch Tutorials\", \"https://pytorch.org/tutorials/\")],\n",
+    "    \"nlp\": [(\"spaCy Course\", \"https://course.spacy.io/\")],\n",
+    "    \"statistics\": [(\"Khan Academy\", \"https://www.khanacademy.org/math/statistics-probability\")],\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f895547f",
+   "metadata": {},
+   "source": [
+    "# CV & JD Parsing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "57293aaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_text_from_pdf(path):\n",
+    "    if PyPDF2 is None: return \"\"\n",
+    "    with open(path, 'rb') as f:\n",
+    "        reader = PyPDF2.PdfReader(f)\n",
+    "        return \"\\n\".join([p.extract_text() or \"\" for p in reader.pages])\n",
+    "\n",
+    "def extract_text_from_docx(path):\n",
+    "    if docx is None: return \"\"\n",
+    "    doc = docx.Document(path)\n",
+    "    return \"\\n\".join([p.text for p in doc.paragraphs])\n",
+    "\n",
+    "def load_cv_text(path, manual):\n",
+    "    if path and os.path.exists(path):\n",
+    "        if path.endswith(\".pdf\"): return extract_text_from_pdf(path)\n",
+    "        if path.endswith(\".docx\"): return extract_text_from_docx(path)\n",
+    "        if path.endswith(\".txt\"): return open(path).read()\n",
+    "    return manual\n",
+    "\n",
+    "cv_text = load_cv_text(cv_path, cv_text_manual)\n",
+    "jd_text_norm = re.sub(r\"\\s+\", \" \", jd_text.lower())\n",
+    "cv_text_norm = re.sub(r\"\\s+\", \" \", cv_text.lower())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1a51f36",
+   "metadata": {},
+   "source": [
+    "# Skill Gap Analysis - Regex Baseline Detector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "09e29115",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def skill_patterns(skill):\n",
+    "    base = [skill.lower()] + SKILL_TAXONOMY[skill][\"aliases\"]\n",
+    "    return [re.compile(rf\"\\b{re.escape(x)}\\b\", re.I) for x in base]\n",
+    "\n",
+    "def detect_skills_regex(text):\n",
+    "    found = {}\n",
+    "    for skill in SKILL_TAXONOMY:\n",
+    "        pats = skill_patterns(skill)\n",
+    "        cnt = sum(len(p.findall(text)) for p in pats)\n",
+    "        if cnt > 0:\n",
+    "            found[skill] = cnt\n",
+    "    return found\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c2b15c1",
+   "metadata": {},
+   "source": [
+    "# LLM Skill Extraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9a2426f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prompt_for_skills(cv, jd):\n",
+    "    taxonomy_list = \"\\n\".join(f\"- {k}\" for k in SKILL_TAXONOMY)\n",
+    "    return f\"\"\"\n",
+    "Extract which skills from this taxonomy appear in the CV and JD.\n",
+    "Return JSON with keys: \"cv_skills\", \"jd_skills\".\n",
+    "\n",
+    "TAXONOMY:\n",
+    "{taxonomy_list}\n",
+    "\n",
+    "CV:\n",
+    "{cv[:3000]}\n",
+    "\n",
+    "JD:\n",
+    "{jd[:3000]}\n",
+    "\"\"\"\n",
+    "\n",
+    "def extract_skills_llm(cv, jd):\n",
+    "    try:\n",
+    "        prompt = prompt_for_skills(cv, jd)\n",
+    "        if OPENAI_AVAILABLE and OPENAI_API_KEY:\n",
+    "            from openai import OpenAI\n",
+    "            client = OpenAI(api_key=OPENAI_API_KEY)\n",
+    "            resp = client.chat.completions.create(\n",
+    "                model=OPENAI_MODEL,\n",
+    "                messages=[{\"role\":\"user\",\"content\": prompt}],\n",
+    "                temperature=0\n",
+    "            )\n",
+    "            data = json.loads(resp.choices[0].message.content)\n",
+    "            return data\n",
+    "    except Exception as e:\n",
+    "        print(\"LLM failed:\", e)\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3ebb0899",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CV skills: ['python', 'git', 'sql', 'pandas', 'numpy', 'pytorch', 'statistics', 'excel', 'tableau']\n",
+      "JD skills: ['python', 'git']\n",
+      "Missing skills: []\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run Detection\n",
+    "llm_result = extract_skills_llm(cv_text_norm, jd_text_norm)\n",
+    "if llm_result:\n",
+    "    cv_skills = {s:1 for s in llm_result[\"cv_skills\"]}\n",
+    "    jd_skills = {s:1 for s in llm_result[\"jd_skills\"]}\n",
+    "else:\n",
+    "    cv_skills = detect_skills_regex(cv_text_norm)\n",
+    "    jd_skills = detect_skills_regex(jd_text_norm)\n",
+    "\n",
+    "missing = [s for s in jd_skills if s not in cv_skills]\n",
+    "print(\"CV skills:\", list(cv_skills))\n",
+    "print(\"JD skills:\", list(jd_skills))\n",
+    "print(\"Missing skills:\", missing)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a1d25f1",
+   "metadata": {},
+   "source": [
+    "# Personalized Learning Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f8384dba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ORDER = [\"python\",\"git\",\"sql\",\"pandas\",\"numpy\",\"scikit-learn\",\"nlp\",\"tensorflow\",\"pytorch\"]\n",
+    "\n",
+    "def build_path(missing):\n",
+    "    ordered = sorted(missing, key=lambda s: ORDER.index(s) if s in ORDER else 999)\n",
+    "    plan = []\n",
+    "    for s in ordered:\n",
+    "        cat = SKILL_TAXONOMY[s][\"category\"]\n",
+    "        res = FREE_RESOURCES.get(s, [])\n",
+    "        plan.append({\n",
+    "            \"Skill\": s,\n",
+    "            \"Category\": cat,\n",
+    "            \"Weeks\": 1 if s in [\"git\",\"excel\"] else 2,\n",
+    "            \"Resources\": res\n",
+    "        })\n",
+    "    return plan\n",
+    "\n",
+    "learning_plan = build_path(missing)\n",
+    "pd.DataFrame(learning_plan)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06041726",
+   "metadata": {},
+   "source": [
+    "# Project Ideas (Portfolio Builders)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1e79251b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Suggested role: data analyst\n",
+      "- KPI dashboard\n",
+      "- Cohort analysis\n",
+      "- Sales forecasting\n"
+     ]
+    }
+   ],
+   "source": [
+    "ROLE_IDEAS = {\n",
+    "    \"data scientist\": [\"End-to-end ML project\", \"NLP classifier\", \"Time series forecasting\"],\n",
+    "    \"data analyst\": [\"KPI dashboard\", \"Cohort analysis\", \"Sales forecasting\"]\n",
+    "}\n",
+    "\n",
+    "role = \"data scientist\" if \"scientist\" in jd_text_norm else \"data analyst\"\n",
+    "print(\"Suggested role:\", role)\n",
+    "for idea in ROLE_IDEAS[role]:\n",
+    "    print(\"-\", idea)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "521a790f",
+   "metadata": {},
+   "source": [
+    "# Export Report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fa2fb5ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Report saved to skillbridge_report.md\n"
+     ]
+    }
+   ],
+   "source": [
+    "report = []\n",
+    "report.append(\"# SkillBridge Plan\\n\")\n",
+    "report.append(\"## Skills\\n\")\n",
+    "report.append(f\"CV skills: {list(cv_skills)}\\n\")\n",
+    "report.append(f\"JD skills: {list(jd_skills)}\\n\")\n",
+    "report.append(f\"Missing: {missing}\\n\")\n",
+    "\n",
+    "report.append(\"\\n## Learning Path\\n\")\n",
+    "for row in learning_plan:\n",
+    "    report.append(f\"- {row['Skill']} ({row['Category']}), {row['Weeks']} weeks\")\n",
+    "\n",
+    "out_path = \"skillbridge_report.md\"\n",
+    "with open(out_path,\"w\") as f:\n",
+    "    f.write(\"\\n\".join(report))\n",
+    "\n",
+    "print(\"Report saved to\", out_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c7e516e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR introduces the first version of the CV → Skill Gap Analyzer notebook.

✅ Features:
- Accepts CV text (manual or PDF upload).
- Extracts skills using simple keyword matching.
- Compares against target role taxonomy (toy example).
- Outputs overlap, gaps, and learning path JSON.
- Exports results for frontend integration.

📌 Next Steps:
- Replace toy taxonomy with ESCO/O*NET dataset.
- Add embeddings for semantic skill matching.
- Connect to live course APIs (Class Central, Coursera).
- Wrap as a FastAPI endpoint for frontend use.
